### PR TITLE
Harden local trust boundary and fix signing-path bugs

### DIFF
--- a/packages/server/src/api/routes.ts
+++ b/packages/server/src/api/routes.ts
@@ -1,16 +1,9 @@
 import { Hono } from 'hono'
-import { cors } from 'hono/cors'
 
 import { logger } from '../logger.js'
-import {
-  getAllPendingIds,
-  getPendingRequest,
-  resolvePendingRequest,
-} from '../pending/store.js'
+import { getPendingRequest, resolvePendingRequest } from '../pending/store.js'
 
 const api = new Hono()
-
-api.use('/*', cors())
 
 // Get a pending request by ID
 api.get('/pending/:id', (c) => {
@@ -51,11 +44,21 @@ api.post('/tx/:id/hash', async (c) => {
 // Complete a pending request
 api.post('/complete/:id', async (c) => {
   const { id } = c.req.param()
-  const body = await c.req.json<{
-    success: boolean
-    result?: string
-    error?: string
-  }>()
+
+  let body: { success?: boolean; result?: string; error?: string } | null = null
+  try {
+    body = await c.req.json<{
+      success?: boolean
+      result?: string
+      error?: string
+    }>()
+  } catch {
+    return c.json({ error: 'Invalid JSON payload' }, 400)
+  }
+
+  if (typeof body?.success !== 'boolean') {
+    return c.json({ error: 'Missing or invalid "success" field' }, 400)
+  }
 
   const resolved = resolvePendingRequest(id, {
     success: body.success,
@@ -67,12 +70,6 @@ api.post('/complete/:id', async (c) => {
     return c.json({ error: 'Request not found or already completed' }, 404)
   }
   return c.json({ ok: true })
-})
-
-// List all pending request IDs (useful for debugging)
-api.get('/pending', (c) => {
-  const ids = getAllPendingIds()
-  return c.json({ pending: ids })
 })
 
 export { api }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -59,7 +59,11 @@ async function main(): Promise<void> {
     open: boolean
   }>()
 
-  const port = parseInt(options.port, 10)
+  const port = Number.parseInt(options.port, 10)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    logger.fatal(`Invalid --port value: ${options.port}`)
+    process.exit(1)
+  }
 
   logger.dim('Checking upstream RPC chain ID...')
   let chainIdHex: string
@@ -95,6 +99,9 @@ async function main(): Promise<void> {
   serve({
     fetch: server.fetch,
     port,
+    // Bind to loopback only. This server triggers wallet signing, so it must
+    // never be reachable from other machines on the network.
+    hostname: '127.0.0.1',
   })
 
   logger.raw(`

--- a/packages/server/src/pending/store.ts
+++ b/packages/server/src/pending/store.ts
@@ -12,6 +12,7 @@ import type {
 interface PendingEntry {
   request: PendingRequest
   resolve: (result: PendingRequestResult) => void
+  timer: ReturnType<typeof setTimeout>
 }
 
 type PendingResult = { id: string; promise: Promise<PendingRequestResult> }
@@ -19,6 +20,9 @@ type PendingResult = { id: string; promise: Promise<PendingRequestResult> }
 const pending = new Map<string, PendingEntry>()
 
 const REQUEST_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+
+// Cap the number of concurrent pending requests to bound memory / open tabs.
+const MAX_PENDING = 100
 
 export function createPendingTransaction(
   jsonRpcId: number | string,
@@ -72,22 +76,28 @@ function createPendingEntry(
   id: string,
   request: PendingRequest
 ): PendingResult {
+  if (pending.size >= MAX_PENDING) {
+    throw new Error('Too many pending requests')
+  }
+
   let resolve: (result: PendingRequestResult) => void
   const promise = new Promise<PendingRequestResult>((res) => {
     resolve = res
   })
 
-  // Store entry (resolve is guaranteed assigned after Promise constructor)
-  pending.set(id, { request, resolve: resolve! })
-
   // Auto-timeout after 5 minutes
-  setTimeout(() => {
+  const timer = setTimeout(() => {
     const entry = pending.get(id)
     if (entry) {
       entry.resolve({ success: false, error: 'Request timed out' })
       pending.delete(id)
     }
   }, REQUEST_TIMEOUT_MS)
+  // Don't let a pending request keep the process alive on its own.
+  timer.unref?.()
+
+  // Store entry (resolve is guaranteed assigned after Promise constructor)
+  pending.set(id, { request, resolve: resolve!, timer })
 
   return { id, promise }
 }
@@ -105,15 +115,8 @@ export function resolvePendingRequest(
     return false
   }
 
+  clearTimeout(entry.timer)
   entry.resolve(result)
   pending.delete(id)
   return true
-}
-
-export function getPendingCount(): number {
-  return pending.size
-}
-
-export function getAllPendingIds(): string[] {
-  return Array.from(pending.keys())
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,8 +1,7 @@
 import { serveStatic } from '@hono/node-server/serve-static'
 import { existsSync, readFileSync } from 'fs'
-import type { Context } from 'hono'
+import type { Context, Next } from 'hono'
 import { Hono } from 'hono'
-import { cors } from 'hono/cors'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
@@ -33,10 +32,49 @@ export interface ServerConfig {
   onPendingRequest: (id: string, url: string) => void
 }
 
+// Maximum number of requests accepted in a single JSON-RPC batch. Prevents a
+// single POST from spawning an unbounded number of pending requests / tabs.
+const MAX_BATCH_SIZE = 50
+
+/**
+ * Restrict the server to local use only. This is the security boundary: the
+ * server triggers wallet-signing prompts and exposes pending-transaction data,
+ * so it must not be drivable by other websites or other machines.
+ *
+ * - Host allowlist blocks DNS-rebinding (a remote page resolving a hostname to
+ *   127.0.0.1 still sends its own Host header).
+ * - Origin allowlist blocks cross-origin browser requests (CSRF). Non-browser
+ *   dev tools (Foundry, Hardhat, curl) send no Origin header and are allowed.
+ */
+function createLocalOnlyGuard(port: number) {
+  const allowedHosts = new Set([
+    `localhost:${port}`,
+    `127.0.0.1:${port}`,
+    `[::1]:${port}`,
+  ])
+  const allowedOrigins = new Set([
+    `http://localhost:${port}`,
+    `http://127.0.0.1:${port}`,
+    `http://[::1]:${port}`,
+  ])
+
+  return async function localOnlyGuard(c: Context, next: Next) {
+    const host = c.req.header('host')
+    if (!host || !allowedHosts.has(host)) {
+      return c.text('Forbidden', 403)
+    }
+    const origin = c.req.header('origin')
+    if (origin && !allowedOrigins.has(origin)) {
+      return c.text('Forbidden', 403)
+    }
+    return next()
+  }
+}
+
 export function createServer(config: ServerConfig): Hono {
   const app = new Hono()
 
-  app.use('*', cors())
+  app.use('*', createLocalOnlyGuard(config.port))
 
   // Mount API routes
   app.route('/api', api)
@@ -56,6 +94,16 @@ export function createServer(config: ServerConfig): Hono {
 
       // Handle batch requests
       if (Array.isArray(body)) {
+        if (body.length > MAX_BATCH_SIZE) {
+          return c.json(
+            {
+              jsonrpc: '2.0',
+              id: null,
+              error: { code: -32600, message: 'Batch too large' },
+            },
+            400
+          )
+        }
         const methods = body.map((req: JsonRpcRequest) => req.method).join(', ')
         logger.dim(`<- [${methods}]`)
         const responses = await Promise.all(
@@ -95,6 +143,10 @@ export function createServer(config: ServerConfig): Hono {
       fromAddress: config.fromAddress || null,
     })
   )
+
+  // Unknown API routes return JSON 404 instead of falling through to the SPA
+  // page (which would otherwise return 200 HTML for e.g. a mistyped endpoint).
+  app.all('/api/*', (c) => c.json({ error: 'Not found' }, 404))
 
   // Serve static assets from web dist
   app.use('/assets/*', serveStatic({ root: webDistPath }))

--- a/packages/web/src/pages/Transaction.tsx
+++ b/packages/web/src/pages/Transaction.tsx
@@ -1,7 +1,7 @@
 import type { PendingRequest } from 'browser-rpc/types'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useParams } from 'react-router'
-import { type Hex, formatEther } from 'viem'
+import { type Hex, formatEther, isHex } from 'viem'
 import {
   useConnection,
   useSendTransaction,
@@ -64,7 +64,9 @@ function ChainMismatchWarning({
         </p>
       </div>
       <p className="text-muted-foreground mb-3 font-mono text-sm">
-        Please switch to <span className="text-foreground">{expectedChainName}</span> to continue.
+        Please switch to{' '}
+        <span className="text-foreground">{expectedChainName}</span> to
+        continue.
       </p>
       <Button
         variant="outline"
@@ -357,27 +359,45 @@ function ExecuteButton({ request }: { request: PendingRequest }) {
   const { signMessageAsync } = useSignMessage()
   const { signTypedDataAsync } = useSignTypedData()
 
+  // Synchronous re-entrancy guard: `status` only updates on re-render, so two
+  // clicks dispatched before that would both broadcast. A ref blocks instantly.
+  const isExecutingRef = useRef(false)
+
   async function handleExecute(): Promise<void> {
+    if (isExecutingRef.current) return
+    isExecutingRef.current = true
     setStatus('pending')
     setErrorMessage('')
 
+    let result: string
     try {
-      const result = await executeRequest()
-      await completeRequest(request.id, { success: true, result })
-      setStatus('success')
+      result = await executeRequest()
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
       setErrorMessage(message)
       setStatus('error')
-
-      // If user rejected, notify the server
-      if (message.includes('rejected') || message.includes('denied')) {
-        await completeRequest(request.id, {
-          success: false,
-          error: 'User rejected request',
-        })
-      }
+      // Always notify the server on failure so the calling script gets an
+      // immediate rejection instead of blocking until the 5-minute timeout.
+      await completeRequest(request.id, {
+        success: false,
+        error: message,
+      }).catch((completeError) => {
+        console.warn('Failed to notify server of failure', completeError)
+      })
+      isExecutingRef.current = false
+      return
     }
+
+    // The transaction/signature already succeeded on-chain / in the wallet.
+    // A failure reporting completion back to the server is a bookkeeping issue,
+    // not a transaction failure, so don't show the user a scary error.
+    await completeRequest(request.id, { success: true, result }).catch(
+      (completeError) => {
+        console.warn('Failed to notify server of completion', completeError)
+      }
+    )
+    setStatus('success')
+    isExecutingRef.current = false
   }
 
   async function executeRequest(): Promise<string> {
@@ -437,8 +457,12 @@ function ExecuteButton({ request }: { request: PendingRequest }) {
   async function executeSignMessageRequest(
     signMessageRequest: Extract<PendingRequest, { type: 'sign' }>
   ): Promise<string> {
+    const { message } = signMessageRequest
+    // eth_sign / personal_sign deliver the message as a hex string. Passing a
+    // hex string straight to signMessage would sign its UTF-8 characters (the
+    // literal "0x..."); wrap it as `{ raw }` so the decoded bytes are signed.
     return signMessageAsync({
-      message: signMessageRequest.message,
+      message: isHex(message) ? { raw: message } : message,
     })
   }
 


### PR DESCRIPTION
## Why

The proxy triggers wallet signing and exposes pending-transaction data, but it bound to **all network interfaces** with **wildcard CORS** and **no Origin/Host validation**. That means any website the developer visited — or any machine on the same LAN — could:

- inject an `eth_sendTransaction` that auto-opens a wallet-approval tab (a `text/plain` "simple" request skips the CORS preflight, so the side effect fires regardless),
- read the `to`/`value`/`data` of in-flight signing requests via the `/api/pending` enumeration endpoint, and
- forge a result back to Foundry/Hardhat via unauthenticated `/api/complete`.

This PR closes that boundary and fixes several correctness bugs in the signing path found during the same review.

## What changed

### Server — trust boundary
- **Local-only guard** ([server.ts](../blob/security/harden-boundary-and-signing/packages/server/src/server.ts)): rejects requests whose `Host` isn't loopback (`localhost`/`127.0.0.1`/`[::1]:<port>`, blocking DNS rebinding) or whose `Origin` is present and foreign (blocking CSRF). Non-browser tools send no `Origin` and pass through, so Foundry/Hardhat/curl keep working.
- **Bind to `127.0.0.1`** ([index.ts](../blob/security/harden-boundary-and-signing/packages/server/src/index.ts)) so the server is unreachable off-machine; also validates `--port`.
- **Removed `/api/pending`** enumeration (and dead `getAllPendingIds`/`getPendingCount`) — the unguessable UUID is now the only handle to a request.
- **DoS caps**: batch size ≤ 50, concurrent pending ≤ 100.
- **`/api/complete` hardening**: guarded JSON parse (clean 400, not 500) and a required boolean `success`.
- **Timer cleanup** on resolve + `unref`; unknown `/api/*` returns JSON 404 instead of the SPA page.

### Web — signing path
- **`personal_sign`/`eth_sign` sign raw bytes** for hex messages (`{ raw }`) instead of the UTF-8 of the `"0x…"` string, so the signature verifies against what the dapp expects and the wallet popup matches the review screen.
- **Always notify the server on failure** (not just on "rejected"/"denied"), so the calling script gets an immediate rejection instead of hanging until the 5-minute timeout.
- **Success-after-send**: a failure *reporting completion* is logged, not shown to the user as a transaction error (prevents duplicate re-submits).
- **Re-entrancy guard** (`useRef`) so a double-click can't broadcast twice.

## Verification
- `bun run build` (server + web) and `tsc --noEmit` both clean.
- Live smoke test against a running server: tool `eth_chainId` works; cross-origin `eth_sendTransaction` → **403**; foreign `Host` → **403**; `/api/pending` → **404 JSON** (no ID leak); 51-item batch → **400**; malformed/empty `/api/complete` → **400**; valid routes + SPA still **200**.

## Notes for reviewers
- The guard treats a **missing** `Origin` as allowed on purpose — that's how non-browser dev tools reach the RPC. Browsers always send `Origin` on cross-origin POSTs, so the CSRF path is covered.
- Follow-ups from the review left out of this PR: supply-chain hardening (SHA-pin the publish workflow, `bun install --frozen-lockfile`, the `./types` export pointing at unshipped source) and remaining web display-fidelity fixes (chain label vs `tx.chainId`, `formatUnits` decimals, `generate-chains.ts` currency coupling, an error boundary, surfacing nonce/fees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)