### PR TITLE
Add pkg.pr.new preview release workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,7 +8,7 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,32 @@
+name: Preview Release
+
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.8
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Builds the web UI, syncs it into the server package (web-dist), then
+      # builds the server. `bun run --filter web build` also runs `tsc`.
+      - name: Build
+        run: bun run build
+
+      # Include the README in the previewed tarball, matching `publish:server`.
+      - name: Copy README into server package
+        run: cp README.md packages/server/
+
+      # Publish a preview of the `browser-rpc` CLI package for this commit/PR.
+      # `--bin` shows an `npx`/`bunx` command instead of `npm i`.
+      - name: Publish preview
+        run: bunx pkg-pr-new publish './packages/server' --bin


### PR DESCRIPTION
## What

Adds `.github/workflows/preview.yml`, which publishes a **preview build of `browser-rpc` on every push and pull request** via [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new). Modeled on [ens-cli's preview.yml](https://github.com/ensdomains/ens-cli/blob/main/.github/workflows/preview.yml), adapted for this monorepo.

Each run comments an installable, versioned artifact (e.g. `bunx browser-rpc@<sha>`) so a change can be tried end-to-end without cutting a real npm release.

## How it works

1. `bun install --frozen-lockfile`
2. `bun run build` — builds the web UI, syncs it into the server package as `web-dist`, then builds the server. (Web's build also runs `tsc`, so types are checked.)
3. Copies `README.md` into `packages/server/` (matching `publish:server`).
4. `bunx pkg-pr-new publish './packages/server' --bin`

Notes:
- Scoped to `./packages/server` because `browser-rpc` is the only publishable package (`web`/`scripts` are private).
- `--bin` makes the preview comment show a `bunx` command instead of `npm i`, since this is a CLI.
- Bun pinned to `1.2.8` for consistency with `ci.yml` / `publish.yml`.
- `permissions: {}` — pkg.pr.new authenticates via the Actions runtime token plus the GitHub App, so no elevated workflow permissions are granted. No untrusted event input is interpolated into any `run:` step.

## ⚠️ Required before this works

The **pkg.pr.new GitHub App must be installed on this repo**: https://github.com/apps/pkg-pr-new — otherwise the publish step will fail. This needs repo-owner access, so it can't be done from CI.

## Verification

- YAML parses; no tabs.
- Clean local build from a regenerated state succeeds.
- `npm pack --dry-run` on the server package shows the tarball contains exactly `README.md`, `dist/index.js`, and `web-dist/` — no source or secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)