### PR TITLE
Bump workflow actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,13 +16,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.2.8
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Why

`actions/checkout@v4` and `actions/setup-node@v4` run on the **deprecated Node 20 runtime**, which emits a warning in the workflow logs. This bumps them to `@v5` (Node 24) so the warning goes away.

## What changed

| Workflow | Action | Before → After |
|---|---|---|
| `ci.yml` | `actions/checkout` | v4 → **v5** |
| `claude.yml` | `actions/checkout` | v4 → **v5** |
| `publish.yml` | `actions/checkout` | v4 → **v5** |
| `publish.yml` | `actions/setup-node` | v4 → **v5** |

Not changed:
- `oven-sh/setup-bun@v2` — already runs on Node 24.
- `anthropics/claude-code-action@v1` — current major, not a Node 20 source.
- The `preview.yml` workflow was already on `checkout@v5` (added earlier).

Pure version bumps — no inputs or behavior changed, and no untrusted event input is interpolated into any step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)