### PR TITLE
Fix known vulnerabilities in hono, @hono/node-server, react-router and vite

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,14 +22,14 @@
     },
     "packages/server": {
       "name": "browser-rpc",
-      "version": "0.0.9",
+      "version": "0.0.11",
       "bin": {
         "browser-rpc": "dist/index.js",
       },
       "dependencies": {
-        "@hono/node-server": "1.19.8",
+        "@hono/node-server": "1.19.17",
         "commander": "14.0.2",
-        "hono": "4.11.3",
+        "hono": "4.13.0",
       },
       "devDependencies": {
         "@types/node": "22.19.5",
@@ -46,7 +46,7 @@
         "lucide-react": "0.562.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "react-router": "7.12.0",
+        "react-router": "7.18.2",
         "tailwind-merge": "3.4.0",
         "viem": "2.44.0",
         "wagmi": "3.3.2",
@@ -58,7 +58,7 @@
         "@vitejs/plugin-react": "5.1.2",
         "tailwindcss": "4.1.18",
         "typescript": "5.9.3",
-        "vite": "7.3.1",
+        "vite": "7.3.6",
       },
     },
   },
@@ -155,7 +155,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.8", "", { "peerDependencies": { "hono": "^4" } }, "sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA=="],
+    "@hono/node-server": ["@hono/node-server@1.19.17", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -341,7 +341,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "hono": ["hono@4.11.3", "", {}, "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w=="],
+    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
 
     "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
 
@@ -419,7 +419,7 @@
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
-    "react-router": ["react-router@7.12.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw=="],
+    "react-router": ["react-router@7.18.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg=="],
 
     "rollup": ["rollup@4.56.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.56.0", "@rollup/rollup-android-arm64": "4.56.0", "@rollup/rollup-darwin-arm64": "4.56.0", "@rollup/rollup-darwin-x64": "4.56.0", "@rollup/rollup-freebsd-arm64": "4.56.0", "@rollup/rollup-freebsd-x64": "4.56.0", "@rollup/rollup-linux-arm-gnueabihf": "4.56.0", "@rollup/rollup-linux-arm-musleabihf": "4.56.0", "@rollup/rollup-linux-arm64-gnu": "4.56.0", "@rollup/rollup-linux-arm64-musl": "4.56.0", "@rollup/rollup-linux-loong64-gnu": "4.56.0", "@rollup/rollup-linux-loong64-musl": "4.56.0", "@rollup/rollup-linux-ppc64-gnu": "4.56.0", "@rollup/rollup-linux-ppc64-musl": "4.56.0", "@rollup/rollup-linux-riscv64-gnu": "4.56.0", "@rollup/rollup-linux-riscv64-musl": "4.56.0", "@rollup/rollup-linux-s390x-gnu": "4.56.0", "@rollup/rollup-linux-x64-gnu": "4.56.0", "@rollup/rollup-linux-x64-musl": "4.56.0", "@rollup/rollup-openbsd-x64": "4.56.0", "@rollup/rollup-openharmony-arm64": "4.56.0", "@rollup/rollup-win32-arm64-msvc": "4.56.0", "@rollup/rollup-win32-ia32-msvc": "4.56.0", "@rollup/rollup-win32-x64-gnu": "4.56.0", "@rollup/rollup-win32-x64-msvc": "4.56.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg=="],
 
@@ -451,7 +451,7 @@
 
     "viem": ["viem@2.44.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.11.3", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-ERvl+N/mPIUck9OSVZGnt1Ex1pMTwKdtOMIbUXLlGJP3KlxdA+1F+Q1hO21qQToaM/ysjTD50ZPQuKyj4Dk3FA=="],
 
-    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
     "wagmi": ["wagmi@3.3.2", "", { "dependencies": { "@wagmi/connectors": "7.1.2", "@wagmi/core": "3.2.2", "use-sync-external-store": "1.4.0" }, "peerDependencies": { "@tanstack/react-query": ">=5.0.0", "react": ">=18", "typescript": ">=5.7.3", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-WPHuWnEOWpOTko+P9f5pR22y7Ozjq6nJse79uBOk3j6ke4ipbGCzJtXfdh/QGQzYHQTU+Iv5HXjiYeabdjdvaQ=="],
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,8 +28,8 @@
     "sync-web": "rm -rf web-dist && cp -r ../web/dist ./web-dist"
   },
   "dependencies": {
-    "@hono/node-server": "1.19.8",
-    "hono": "4.11.3",
+    "@hono/node-server": "1.19.17",
+    "hono": "4.13.0",
     "commander": "14.0.2"
   },
   "devDependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
     "browser-rpc": "workspace:*",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-router": "7.12.0",
+    "react-router": "7.18.2",
     "@tanstack/react-query": "5.90.16",
     "wagmi": "3.3.2",
     "viem": "2.44.0",
@@ -28,6 +28,6 @@
     "@tailwindcss/vite": "4.1.18",
     "tailwindcss": "4.1.18",
     "typescript": "5.9.3",
-    "vite": "7.3.1"
+    "vite": "7.3.6"
   }
 }


### PR DESCRIPTION
Bumps four dependencies whose pinned versions are covered by published security advisories. All stay within their current major.

| Package | Before | After | Worst advisory fixed |
|---|---|---|---|
| `@hono/node-server` | 1.19.8 | **1.19.17** | Authorization bypass for protected static paths via encoded slashes (**high**) |
| `hono` | 4.11.3 | **4.13.0** | Arbitrary file access via `serveStatic` (**high**); CORS middleware reflecting any Origin with credentials when `origin` defaults to wildcard (**high**) |
| `react-router` | 7.12.0 | **7.18.2** | Unauthenticated DoS via inefficient route matching (**high**); DoS via unbounded path expansion in the `__manifest` endpoint (**high**) |
| `vite` | 7.3.1 | **7.3.6** | `server.fs.deny` bypass via queries and arbitrary file read through the dev-server websocket (**high**, dev-server only) |

### Verification

`bun install` + `bun run build` both pass on this branch — the web bundle builds under vite 7.3.6 and the server bundles cleanly. Lockfile diff is 9 insertions / 9 deletions, limited to the four packages above.

### Notes for review

- **`react-router` deliberately stays on 7.x.** 8.3.0 is available, but 7.18.2 clears the high-severity advisories without a major migration. One advisory (`>=7.12.0 <8.3.0`, RSC-mode CSRF bypass) is only fully cleared by 8.x — it applies to React Router's RSC mode, which this app doesn't use, so it's not a reason to take the major here.
- **`@hono/node-server` stays on 1.x.** The high-severity encoded-slash bypass is fixed in 1.19.10+. A separate moderate advisory (path traversal in `serve-static` on Windows via encoded backslash) is only fixed in 2.0.5+, which is a major bump — worth doing deliberately rather than folding into a security patch.
- Version choices avoid anything published in the last two days: `hono` 4.13.1 shipped yesterday and was intentionally **not** taken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLKXKfBG82ynxV7K447UbQ)_