### PR TITLE
Update hono and viem for security fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     "packages/scripts": {
       "name": "scripts",
       "dependencies": {
-        "viem": "2.44.0",
+        "viem": "2.56.0",
       },
       "devDependencies": {
         "@types/bun": "1.3.5",
@@ -29,7 +29,7 @@
       "dependencies": {
         "@hono/node-server": "2.1.1",
         "commander": "14.0.2",
-        "hono": "4.13.3",
+        "hono": "4.13.5",
       },
       "devDependencies": {
         "@types/node": "22.19.5",
@@ -48,7 +48,7 @@
         "react-dom": "19.2.3",
         "react-router": "7.18.2",
         "tailwind-merge": "3.4.0",
-        "viem": "2.44.0",
+        "viem": "2.56.0",
         "wagmi": "3.3.2",
       },
       "devDependencies": {
@@ -61,9 +61,6 @@
         "vite": "7.3.6",
       },
     },
-  },
-  "overrides": {
-    "ws": "^8.20.1",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
@@ -346,7 +343,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
+    "hono": ["hono@4.13.5", "", {}, "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw=="],
 
     "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
 
@@ -402,7 +399,7 @@
 
     "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
 
-    "ox": ["ox@0.11.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw=="],
+    "ox": ["ox@0.14.34", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ=="],
 
     "parse-imports-exports": ["parse-imports-exports@0.2.4", "", { "dependencies": { "parse-statements": "1.0.11" } }, "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ=="],
 
@@ -454,7 +451,7 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw=="],
 
-    "viem": ["viem@2.44.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.11.3", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-ERvl+N/mPIUck9OSVZGnt1Ex1pMTwKdtOMIbUXLlGJP3KlxdA+1F+Q1hO21qQToaM/ysjTD50ZPQuKyj4Dk3FA=="],
+    "viem": ["viem@2.56.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.34", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-JmkgIk4jN+im4oguLxwPv19pwSaGH9kcGSq25Ilm55106ULBBMNR3eWKKA0wZoeyLPSHIiOwZ4sGceEYEIq7LA=="],
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
@@ -462,7 +459,7 @@
 
     "web": ["web@workspace:packages/web"],
 
-    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
     "prettier": "3.7.4",
     "prettier-plugin-tailwindcss": "0.7.2"
   },
-  "overrides": {
-    "ws": "^8.20.1"
-  },
   "packageManager": "bun@1.2.8"
 }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -6,7 +6,7 @@
     "transfer": "bun run src/transfer.ts"
   },
   "dependencies": {
-    "viem": "2.44.0"
+    "viem": "2.56.0"
   },
   "devDependencies": {
     "@types/bun": "1.3.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@hono/node-server": "2.1.1",
-    "hono": "4.13.3",
+    "hono": "4.13.5",
     "commander": "14.0.2"
   },
   "devDependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,7 +15,7 @@
     "react-router": "7.18.2",
     "@tanstack/react-query": "5.90.16",
     "wagmi": "3.3.2",
-    "viem": "2.44.0",
+    "viem": "2.56.0",
     "clsx": "2.1.1",
     "tailwind-merge": "3.4.0",
     "class-variance-authority": "0.7.1",


### PR DESCRIPTION
## Summary

Scheduled dependency audit. Applied only the changes that fix known security advisories; other available updates were left alone per policy (no meaningful improvement, too-new release, or major/breaking bump not clearly warranted).

### Updated

- **hono**: `4.13.3` → `4.13.5` (packages/server, the published `browser-rpc` npm package)
  - Patch release, security-only. Fixes three issues: a query-string parser bug that mis-reads params after URL fragments (affects Cache Middleware and apps behind proxies/WAFs — relevant here since this server proxies RPC requests), an incomplete fix for a path-traversal bug in Static Site Generation, and a memory-exhaustion issue via unbounded dot-notation expansion in `parseBody({ dot: true })`.
  - No breaking changes; `@hono/node-server@2.1.1` already declares `hono: ^4` so no other bump needed.

- **viem**: `2.44.0` → `2.56.0` (packages/web, packages/scripts)
  - Minor version bump. Motivated by security: viem 2.54.2 bumped its own nested `ws` dependency to `8.21.0`, fixing **GHSA-58qx-3vcg-4xpx / CVE-2026-45736** ("ws: Uninitialized memory disclosure", affects ws 8.0.0–8.20.0). The repo was previously pinned to viem `2.44.0`, which nests the vulnerable `ws@8.18.3`, worked around only via a root-level `overrides.ws` floor.
  - Breaking changes between these versions exist (Tempo module restructuring in 2.56.0, ERC-20 token action refactor in 2.54.0, `nonceKey` rename in 2.46.0, required `chainId` for `signKeyAuthorization` in 2.47.0) but none touch APIs this repo uses — the codebase only imports `createWalletClient`, `http`, `parseEther`, `publicActions`, `viem/chains`, `formatEther`, `isHex`, and the `Chain`/`Hex` types.
  - `wagmi@3.3.2`'s peer range (`viem: 2.x`) is satisfied, no wagmi bump needed.

### Removed

- Root `package.json` `overrides.ws: "^8.20.1"` — this was added in a prior update to force a safe `ws` version workaround for viem's old pinned `ws@8.18.3`. Now that viem itself pins a fixed `ws@8.21.0` directly, the override is redundant (confirmed via a clean `bun install`: `ws` resolves to `8.21.0` with no override present).

### Left unchanged (checked, no action needed)

- `react-router` `7.18.2` — already past the fix versions for the open-redirect (fixed 7.18.0), CSRF (fixed 7.15.1), and DoS (fixed 7.14.0) advisories affecting earlier 7.x releases; not bumping to major `8.x` blind.
- `vite` `7.3.6` — already past the fix version (7.3.2) for the two 2026 arbitrary-file-read/path-traversal dev-server advisories; not bumping to major `8.x` blind.
- `commander`, `typescript`, `@vitejs/plugin-react` — latest available is a major version with real breaking changes (commander 15 is ESM-only + requires Node 22.12; TypeScript 7 is the native/Go-based rewrite; plugin-react 6 targets newer Vite) and no security driver — flagging only, not applying blind.
- `lucide-react` latest (`1.37.0`) is both a major bump and was published 2026-08-29 (within the 2-day freshness window) — skipped on both counts.
- `wagmi`, `@tanstack/react-query`, `react`/`react-dom`, `tailwindcss`, `tailwind-merge`, `prettier` and other devDeps — no CVEs found and no clearly meaningful fix/perf changes in the available minor/patch bumps; left as-is per the "don't churn without benefit" policy.
- `postcss`/`rollup`/`picomatch` overrides in `packages/web` — left in place; unlike `ws`, these floors weren't superseded by a normal upstream release (vite's own version and dependency ranges are unchanged), so removing them isn't clearly justified yet.

### Verification

- `bun install` — lockfile regenerated cleanly, no manual edits.
- `bun run build` — web + server both build successfully.
- `bun run format` — no formatting diffs from the dependency changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJEjkmDtmHNzij9eaWxzu9)_